### PR TITLE
Correction of the comparator in util.sort()

### DIFF
--- a/lib/array/sort.js
+++ b/lib/array/sort.js
@@ -33,6 +33,8 @@ module.exports = function sort(arr, key) {
     return arr.sort();
   }
   return arr.sort(function(a, b) {
-    return a[key] > b[key];
+    var aValue = a[key];
+    var bValue = b[key];
+    return aValue > bValue ? 1 : (aValue < bValue ? -1 : 0);
   });
 };


### PR DESCRIPTION
Function passed to `Array.prototype.sort` should return number, not boolean, i.e., it should return a negative value if the first argument is smaller than the second, zero if they are equal and a positive value otherwise, see [the specification](https://tc39.github.io/ecma262/#sec-array.prototype.sort).